### PR TITLE
Geofence-geostore integrations closes #118 #119

### DIFF
--- a/doc/setup/sql/geofence-geostoreUsersIntegration_scripts/001_setup_geostore_geofence_db.sql
+++ b/doc/setup/sql/geofence-geostoreUsersIntegration_scripts/001_setup_geostore_geofence_db.sql
@@ -1,0 +1,48 @@
+-- ---------------------------
+-- CREATE geostore SCHEMAs  
+-- ---------------------------
+
+CREATE user geostore LOGIN PASSWORD 'geostore' NOSUPERUSER INHERIT NOCREATEDB NOCREATEROLE;
+
+CREATE SCHEMA geostore;
+
+GRANT USAGE ON SCHEMA geostore TO geostore ;
+GRANT ALL ON SCHEMA geostore TO geostore ;
+
+CREATE user geostore_test LOGIN PASSWORD 'geostore_test' NOSUPERUSER INHERIT NOCREATEDB NOCREATEROLE;
+
+CREATE SCHEMA geostore_test;
+
+GRANT USAGE ON SCHEMA geostore_test TO geostore_test;
+GRANT ALL ON SCHEMA geostore_test TO geostore_test;
+
+-- ---------------------------
+-- CREATE geofence SCHEMAs 
+-- ---------------------------
+
+CREATE SCHEMA geofence;
+
+GRANT USAGE ON SCHEMA geofence TO geostore;
+GRANT ALL ON SCHEMA geofence TO geostore;
+
+GRANT SELECT ON public.spatial_ref_sys to geostore;
+GRANT SELECT,INSERT,DELETE ON public.geometry_columns to geostore;
+
+
+-- CREATE SCHEMA geofence_test
+
+CREATE SCHEMA geofence_test;
+
+GRANT USAGE ON SCHEMA geofence_test TO geostore_test;
+GRANT ALL ON SCHEMA geofence_test TO geostore_test;
+
+GRANT SELECT ON public.spatial_ref_sys to geostore_test;
+GRANT SELECT,INSERT,DELETE ON public.geometry_columns to geostore_test;
+
+
+-- -------------------------------------
+-- -------- Set SearchPaths ------------
+-- -------------------------------------
+
+alter user geostore set search_path to geostore, geofence, public;
+alter user geostore_test set search_path to geostore_test, geofence_test, public;

--- a/doc/setup/sql/geofence-geostoreUsersIntegration_scripts/002_create_schema_geostore_postgres.sql
+++ b/doc/setup/sql/geofence-geostoreUsersIntegration_scripts/002_create_schema_geostore_postgres.sql
@@ -1,0 +1,211 @@
+SET search_path TO geostore;
+
+    create table gs_attribute (
+        id int8 not null,
+        attribute_date timestamp,
+        name varchar(255) not null,
+        attribute_number float8,
+        attribute_text varchar(255),
+        attribute_type varchar(255) not null,
+        resource_id int8 not null,
+        primary key (id),
+        unique (name, resource_id)
+    );
+    ALTER TABLE gs_attribute
+          OWNER TO geostore;
+
+    create table gs_category (
+        id int8 not null,
+        name varchar(255) not null,
+        primary key (id),
+        unique (name)
+    );
+    ALTER TABLE gs_category
+          OWNER TO geostore;
+
+    create table gs_resource (
+        id int8 not null,
+        creation timestamp not null,
+        description varchar(255),
+        lastUpdate timestamp,
+        metadata varchar(30000),
+        name varchar(255) not null,
+        category_id int8 not null,
+        primary key (id),
+        unique (name)
+    );
+    ALTER TABLE gs_resource
+          OWNER TO geostore;
+
+    create table gs_security (
+        id int8 not null,
+        canRead bool not null,
+        canWrite bool not null,
+        group_id int8,
+        resource_id int8,
+        user_id int8,
+        primary key (id),
+        unique (user_id, resource_id),
+        unique (resource_id, group_id)
+    );
+    ALTER TABLE gs_security
+          OWNER TO geostore;
+
+    create table gs_stored_data (
+        id int8 not null,
+        stored_data varchar(500000) not null,
+        resource_id int8 not null,
+        primary key (id),
+        unique (resource_id)
+    );
+    ALTER TABLE gs_stored_data
+          OWNER TO geostore;
+
+    create table gs_user (
+        id int8 not null,
+        name varchar(20) not null,
+        user_password varchar(255),
+        user_role varchar(255) not null,
+        group_id int8,
+		enabled char(1) NOT NULL DEFAULT 'Y',
+        primary key (id),
+        unique (name)
+    );
+    ALTER TABLE gs_user
+          OWNER TO geostore;
+
+    create table gs_user_attribute (
+        id int8 not null,
+        name varchar(255) not null,
+        string varchar(255),
+        user_id int8 not null,
+        primary key (id),
+        unique (name, user_id)
+    );
+    ALTER TABLE gs_user_attribute
+          OWNER TO geostore;
+
+    create table gs_usergroup (
+        id int8 not null,
+        groupName varchar(20) not null,
+		description varchar(200),
+		enabled char(1) NOT NULL DEFAULT 'Y',
+        primary key (id),
+        unique (groupName)
+    );
+    ALTER TABLE gs_usergroup
+          OWNER TO geostore;
+	
+	create table gs_usergroup_members (
+		user_id int8 not null, 
+		group_id int8 not null, 
+		primary key (user_id, group_id)
+	);
+    ALTER TABLE gs_usergroup_members
+          OWNER TO geostore;
+	
+	alter table gs_usergroup_members 
+		add constraint FKFDE460DB62224F72 
+		foreign key (user_id) 
+		references gs_user;
+		
+    alter table gs_usergroup_members 
+		add constraint FKFDE460DB9EC981B7 
+		foreign key (group_id) 
+		references gs_usergroup;
+
+    create index idx_attribute_name on gs_attribute (name);
+
+    create index idx_attribute_resource on gs_attribute (resource_id);
+
+    create index idx_attribute_text on gs_attribute (attribute_text);
+
+    create index idx_attribute_type on gs_attribute (attribute_type);
+
+    create index idx_attribute_date on gs_attribute (attribute_date);
+
+    create index idx_attribute_number on gs_attribute (attribute_number);
+
+    alter table gs_attribute 
+        add constraint fk_attribute_resource 
+        foreign key (resource_id) 
+        references gs_resource;
+
+    create index idx_category_type on gs_category (name);
+
+    create index idx_resource_name on gs_resource (name);
+
+    create index idx_resource_description on gs_resource (description);
+
+    create index idx_resource_metadata on gs_resource (metadata);
+
+    create index idx_resource_update on gs_resource (lastUpdate);
+
+    create index idx_resource_creation on gs_resource (creation);
+
+    create index idx_resource_category on gs_resource (category_id);
+
+    alter table gs_resource 
+        add constraint fk_resource_category 
+        foreign key (category_id) 
+        references gs_category;
+
+    create index idx_security_resource on gs_security (resource_id);
+
+    create index idx_security_user on gs_security (user_id);
+
+    create index idx_security_group on gs_security (group_id);
+
+    create index idx_security_write on gs_security (canWrite);
+
+    create index idx_security_read on gs_security (canRead);
+
+    alter table gs_security 
+        add constraint fk_security_user 
+        foreign key (user_id) 
+        references gs_user;
+
+    alter table gs_security 
+        add constraint fk_security_group 
+        foreign key (group_id) 
+        references gs_usergroup;
+
+    alter table gs_security 
+        add constraint fk_security_resource 
+        foreign key (resource_id) 
+        references gs_resource;
+
+    alter table gs_stored_data 
+        add constraint fk_data_resource 
+        foreign key (resource_id) 
+        references gs_resource;
+
+    create index idx_user_group on gs_user (group_id);
+
+    create index idx_user_password on gs_user (user_password);
+
+    create index idx_user_name on gs_user (name);
+
+    create index idx_user_role on gs_user (user_role);
+
+    alter table gs_user 
+        add constraint fk_user_ugroup 
+        foreign key (group_id) 
+        references gs_usergroup;
+
+    create index idx_user_attribute_name on gs_user_attribute (name);
+
+    create index idx_user_attribute_text on gs_user_attribute (string);
+
+    create index idx_attribute_user on gs_user_attribute (user_id);
+
+    alter table gs_user_attribute 
+        add constraint fk_uattrib_user 
+        foreign key (user_id) 
+        references gs_user;
+
+    create index idx_usergroup_name on gs_usergroup (groupName);
+
+    create sequence hibernate_sequence;
+    ALTER TABLE hibernate_sequence
+          OWNER TO geostore;

--- a/doc/setup/sql/geofence-geostoreUsersIntegration_scripts/003_create_schema_geofence_postgres.sql
+++ b/doc/setup/sql/geofence-geostoreUsersIntegration_scripts/003_create_schema_geofence_postgres.sql
@@ -1,0 +1,199 @@
+set search_path to geofence;
+
+-- CLEAN-UP
+--drop table gf_gfuser cascade;
+--drop table gf_rule_limits;
+--drop table gf_layer_styles;
+--drop table gf_layer_custom_props ;
+--drop table gf_layer_attributes;
+--drop table gf_layer_details;
+--drop table gf_rule cascade;
+--drop table gf_gsuser cascade;
+--drop table gf_gsinstance cascade;
+--drop table gf_user_usergroups;
+--drop table gf_usergroup cascade;
+
+-- drop view geofence.gf_gsuser;
+-- drop view geofence.gf_user_usergroups;
+-- drop view geofence.gf_usergroup;
+
+--drop sequence hibernate_sequence;
+
+-- TABLE CREATION
+    create table gf_gfuser (
+        id int8 not null,
+        dateCreation timestamp,
+        emailAddress varchar(255),
+        enabled bool not null,
+        extId varchar(255) unique,
+        fullName varchar(255),
+        name varchar(255) not null unique,
+        password varchar(255),
+        primary key (id)
+    );
+
+    create table gf_gsinstance (
+        id int8 not null,
+        baseURL varchar(255) not null,
+        dateCreation timestamp,
+        description varchar(255),
+        name varchar(255) not null,
+        password varchar(255) not null,
+        username varchar(255) not null,
+        primary key (id)
+    );
+
+    create table gf_layer_attributes (
+        details_id int8 not null,
+        access_type varchar(255),
+        data_type varchar(255),
+        name varchar(255) not null,
+        primary key (details_id, name),
+        unique (details_id, name)
+    );
+
+    create table gf_layer_custom_props (
+        details_id int8 not null,
+        propvalue varchar(255),
+        propkey varchar(255),
+        primary key (details_id, propkey)
+    );
+
+    create table gf_layer_details (
+        id int8 not null,
+        area public.geometry,
+        cqlFilterRead varchar(4000),
+        cqlFilterWrite varchar(4000),
+        defaultStyle varchar(255),
+        catalog_mode varchar(255),
+		type varchar(255),
+        rule_id int8 not null,
+        primary key (id),
+        unique (rule_id)
+    );
+
+    create table gf_layer_styles (
+        details_id int8 not null,
+        styleName varchar(255)
+    );
+
+    create table gf_rule (
+        id int8 not null,
+        grant_type varchar(255) not null,
+		ip_high bigint,
+		ip_low bigint,
+		ip_size integer,
+        layer varchar(255),
+        priority int8 not null,
+        request varchar(255),
+        service varchar(255),
+        workspace varchar(255),
+        gsuser_id int8,
+        instance_id int8,
+        userGroup_id int8,
+        primary key (id),
+        unique (gsuser_id, userGroup_id, instance_id, service, request, workspace, layer)
+    );
+
+    create table gf_rule_limits (
+        id int8 not null,
+        area public.geometry,
+		catalog_mode varchar(255),
+        rule_id int8 not null,
+        primary key (id),
+        unique (rule_id)
+    );
+
+	------- VIEW gf_gsuser -------
+	create or replace view geofence.gf_gsuser as
+		select gs_user.id, 
+				current_timestamp as datecreation, 
+				character varying(255)'' as emailaddress, 
+				character varying(255) '' as extid, 
+				character varying(255) '' as fullname, 
+				-- the password used here is: "This_is_an_AES_hardcoded_password" (note that it is also base64 encoded)
+				gs_user.name, character varying(255) 'SWsIywoxKmqlGSjVedSqrpYd4/HBBn0pV+NmEEtta1T/do0NQNH6PM4Auj8EpwvX' as password,
+				cast(gs_user.enabled as boolean), 
+				case 
+					when user_role='ADMIN' 
+						then true 
+						else false 
+					end 
+				as admin
+		from geostore.gs_user;
+   
+	------- VIEW gf_user_usergroups -------
+	create or replace view geofence.gf_user_usergroups as
+		select gs_usergroup_members.user_id, 
+				gs_usergroup_members.group_id
+		from geostore.gs_usergroup_members;
+   
+	------- VIEW gf_usergroup -------
+	create or replace view geofence.gf_usergroup as
+		select gs_usergroup.id, 
+				timestamp without time zone '0001-01-01 00:00:00' as datecreation, 
+				cast(gs_usergroup.enabled as boolean), 
+				character varying(255)'' as extid, 
+				gs_usergroup.groupname as name
+		from geostore.gs_usergroup;
+	
+	
+    alter table gf_layer_attributes
+        add constraint fk_attribute_layer
+        foreign key (details_id)
+        references gf_layer_details;
+
+    alter table gf_layer_custom_props
+        add constraint fk_custom_layer
+        foreign key (details_id)
+        references gf_layer_details;
+
+    alter table gf_layer_details
+        add constraint fk_details_rule
+        foreign key (rule_id)
+        references gf_rule;
+
+    alter table gf_layer_styles
+        add constraint fk_styles_layer
+        foreign key (details_id)
+        references gf_layer_details;
+
+    create index idx_rule_request on gf_rule (request);
+
+    create index idx_rule_layer on gf_rule (layer);
+
+    create index idx_rule_service on gf_rule (service);
+
+    create index idx_rule_workspace on gf_rule (workspace);
+
+    create index idx_rule_priority on gf_rule (priority);
+
+    alter table gf_rule
+        add constraint fk_rule_instance
+        foreign key (instance_id)
+        references gf_gsinstance;
+
+    alter table gf_rule_limits
+        add constraint fk_limits_rule
+        foreign key (rule_id)
+        references gf_rule;
+
+    create sequence hibernate_sequence;
+
+--GRANTS
+alter table gf_gfuser owner to geostore;
+alter table gf_rule_limits owner to geostore;
+alter table gf_layer_styles owner to geostore;
+alter table gf_layer_custom_props owner to geostore;
+alter table gf_layer_attributes owner to geostore;
+alter table gf_layer_details owner to geostore;
+alter table gf_rule owner to geostore;
+alter table gf_gsinstance owner to geostore;
+alter view gf_gsuser owner to geostore;
+alter view gf_user_usergroups owner to geostore;
+alter view geofence.gf_usergroup owner to geostore;
+
+alter sequence hibernate_sequence owner to geostore;
+
+--DEFAULTS
+insert into geofence.gf_gfuser(id, datecreation, emailaddress, enabled, extid, fullname, "name", "password") values (0, 'now', null, true, 0, 'admin', 'admin', '21232f297a57a5a743894ae4a801fc3');

--- a/doc/setup/sql/geofence-geostoreUsersIntegration_scripts/readme.markdown
+++ b/doc/setup/sql/geofence-geostoreUsersIntegration_scripts/readme.markdown
@@ -1,0 +1,17 @@
+GeoFence geoStore integration
+=================================
+
+This folder contains the DDL scripts to create a common database shared between **GeoFence** and **GeoStore** that allow **GeoFence** to use the *Users and Groups* stored on **GeoStore** that could also be shared with **GeoServer**.
+These scripts require an empty postgres database spatially enabled.
+The script will create all the tables and views in 2 schemas called `geostore` and `geofence` plus it will create other 2 empty schemas called `geostore_test` and `geofence_test` for testing pourposes.
+All the schemas and all the objects will be owned by the script-created user called `geostore`
+
+Instructions
+==================================================
+
+* Create a new database, the admin can freely choose the db-name
+* Enable the postgres geospatial extensions, postGIS: run the query `CREATE EXTENSION postgis;` (Please note that the CREATE EXTENSION statement is available only with postgres version >= 2.0)
+* Run the DDL scripts you can find in this directory in the order indicated by the files suffixes (001, 002, 003) Please note that the db **should be empty** because if the user, schemas or tables that the scripts try to create are already/partially present the script will fail.
+* Install on two different tomcat instances GeoStore and Geofence and configure both to use the created database: configure properly the schema names: *geofence* must work on **geofence** schema and *geostore* on **geostore** schema
+* Run the applications, the startup order is not important.
+* Enjoy!

--- a/src/gui/core/plugin/userui/pom.xml
+++ b/src/gui/core/plugin/userui/pom.xml
@@ -123,6 +123,13 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+        
+        <dependency>
+		    <groupId>org.slf4j</groupId>
+		    <artifactId>slf4j-log4j12</artifactId>
+		    <version>1.7.7</version>
+		    <scope>test</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>junit</groupId>
@@ -255,4 +262,34 @@
 		</resources>
 
 	</build>
+	
+	<profiles>
+		<profile>
+	       	<id>geostoreIntegration</id>
+	       	<build>
+				<plugins>
+					<plugin>
+						<artifactId>maven-antrun-plugin</artifactId>
+						<version>1.7</version>
+						<executions>
+							<execution>
+								<phase>compile</phase>
+								<configuration>
+									<tasks>
+										<echo message="Replacing tokens, the output directory is: ${project.build.outputDirectory}" />
+										<replace file="${project.build.outputDirectory}/it/geosolutions/geofence/gui/server/service/impl/activateTabs.properties" token="true" value="false" />
+									</tasks>
+								</configuration>
+								<goals>
+									<goal>run</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+	
+	
 </project>

--- a/src/gui/core/plugin/userui/src/main/java/it/geosolutions/geofence/gui/client/controller/ProfilesController.java
+++ b/src/gui/core/plugin/userui/src/main/java/it/geosolutions/geofence/gui/client/controller/ProfilesController.java
@@ -40,6 +40,7 @@ import com.google.gwt.user.client.rpc.AsyncCallback;
 
 import it.geosolutions.geofence.gui.client.GeofenceEvents;
 import it.geosolutions.geofence.gui.client.model.UserGroup;
+import it.geosolutions.geofence.gui.client.service.GsUsersManagerRemoteServiceAsync;
 import it.geosolutions.geofence.gui.client.service.ProfilesManagerRemoteServiceAsync;
 import it.geosolutions.geofence.gui.client.view.ProfilesView;
 import it.geosolutions.geofence.gui.client.widget.ProfileGridWidget;
@@ -57,6 +58,10 @@ public class ProfilesController extends Controller
     /** The Constant PROFILES_TAB_ITEM_ID. */
     private static final String PROFILES_TAB_ITEM_ID = "ProfilesTabItem";
 
+    /** The gs manager service remote. */
+    private GsUsersManagerRemoteServiceAsync gsManagerServiceRemote =
+        GsUsersManagerRemoteServiceAsync.Util.getInstance();
+    
     /** The profiles manager service remote. */
     private ProfilesManagerRemoteServiceAsync profilesManagerServiceRemote =
         ProfilesManagerRemoteServiceAsync.Util.getInstance();
@@ -151,7 +156,7 @@ public class ProfilesController extends Controller
         if (tabWidget == null)
         {
             tabWidget = (TabWidget) event.getData();
-            tabWidget.add(new ProfilesTabItem(PROFILES_TAB_ITEM_ID, profilesManagerServiceRemote));
+            tabWidget.add(new ProfilesTabItem(PROFILES_TAB_ITEM_ID, profilesManagerServiceRemote, gsManagerServiceRemote));
         }
     }
 

--- a/src/gui/core/plugin/userui/src/main/java/it/geosolutions/geofence/gui/client/controller/UsersController.java
+++ b/src/gui/core/plugin/userui/src/main/java/it/geosolutions/geofence/gui/client/controller/UsersController.java
@@ -32,15 +32,7 @@
  */
 package it.geosolutions.geofence.gui.client.controller;
 
-import com.extjs.gxt.ui.client.mvc.AppEvent;
-import com.extjs.gxt.ui.client.mvc.Controller;
-import com.extjs.gxt.ui.client.mvc.Dispatcher;
-import com.extjs.gxt.ui.client.widget.TabItem;
-import com.extjs.gxt.ui.client.widget.grid.Grid;
-import com.google.gwt.user.client.rpc.AsyncCallback;
-
 import it.geosolutions.geofence.gui.client.GeofenceEvents;
-import it.geosolutions.geofence.gui.client.i18n.I18nProvider;
 import it.geosolutions.geofence.gui.client.model.GSUser;
 import it.geosolutions.geofence.gui.client.service.GsUsersManagerRemoteServiceAsync;
 import it.geosolutions.geofence.gui.client.service.ProfilesManagerRemoteServiceAsync;
@@ -48,6 +40,13 @@ import it.geosolutions.geofence.gui.client.view.UsersView;
 import it.geosolutions.geofence.gui.client.widget.UserGridWidget;
 import it.geosolutions.geofence.gui.client.widget.tab.GsUsersTabItem;
 import it.geosolutions.geofence.gui.client.widget.tab.TabWidget;
+
+import com.extjs.gxt.ui.client.mvc.AppEvent;
+import com.extjs.gxt.ui.client.mvc.Controller;
+import com.extjs.gxt.ui.client.mvc.Dispatcher;
+import com.extjs.gxt.ui.client.widget.TabItem;
+import com.extjs.gxt.ui.client.widget.grid.Grid;
+import com.google.gwt.user.client.rpc.AsyncCallback;
 
 
 // TODO: Auto-generated Javadoc

--- a/src/gui/core/plugin/userui/src/main/java/it/geosolutions/geofence/gui/client/service/GsUsersManagerRemoteService.java
+++ b/src/gui/core/plugin/userui/src/main/java/it/geosolutions/geofence/gui/client/service/GsUsersManagerRemoteService.java
@@ -94,5 +94,14 @@ public interface GsUsersManagerRemoteService extends RemoteService
      * @throws ApplicationException
      */
     public UserLimitsInfo saveUserLimitsInfo(UserLimitsInfo userLimitInfo) throws ApplicationException;
+    
+    
+    /**
+     * This service returns to the client the information about the need for load the users and group management tabs
+     * 
+     * @return true if the tab must be loaded, false otherwise
+     * @throws ApplicationException
+     */
+    public boolean activateUserGroupTabs() throws ApplicationException;
 
 }

--- a/src/gui/core/plugin/userui/src/main/java/it/geosolutions/geofence/gui/client/widget/tab/GsUsersTabItem.java
+++ b/src/gui/core/plugin/userui/src/main/java/it/geosolutions/geofence/gui/client/widget/tab/GsUsersTabItem.java
@@ -32,15 +32,15 @@
  */
 package it.geosolutions.geofence.gui.client.widget.tab;
 
-import com.extjs.gxt.ui.client.Style.Scroll;
-import com.extjs.gxt.ui.client.widget.TabItem;
-
 import it.geosolutions.geofence.gui.client.Constants;
 import it.geosolutions.geofence.gui.client.Resources;
 import it.geosolutions.geofence.gui.client.i18n.I18nProvider;
 import it.geosolutions.geofence.gui.client.service.GsUsersManagerRemoteServiceAsync;
 import it.geosolutions.geofence.gui.client.service.ProfilesManagerRemoteServiceAsync;
 import it.geosolutions.geofence.gui.client.widget.UserManagementWidget;
+
+import com.extjs.gxt.ui.client.Style.Scroll;
+import com.extjs.gxt.ui.client.widget.TabItem;
 
 
 // TODO: Auto-generated Javadoc
@@ -52,7 +52,7 @@ public class GsUsersTabItem extends TabItem
 
     /** The profile management widget. */
     private UserManagementWidget userManagementWidget;
-
+    
     /**
      * Instantiates a new gs users tab item.
      */
@@ -84,6 +84,9 @@ public class GsUsersTabItem extends TabItem
         add(getUserManagementWidget());
 
         getUserManagementWidget().getUsersInfo().getLoader().load(0, it.geosolutions.geofence.gui.client.Constants.DEFAULT_PAGESIZE);
+        
+        //Deactivate the "User Management" tab as configured in the activateTabs.property (Use Case geostoreIntegration)  
+        TabUtils.deactivateTabIfNeeded(gsManagerServiceRemote, this);
     }
 
     /**
@@ -106,5 +109,4 @@ public class GsUsersTabItem extends TabItem
     {
         return userManagementWidget;
     }
-
 }

--- a/src/gui/core/plugin/userui/src/main/java/it/geosolutions/geofence/gui/client/widget/tab/ProfilesTabItem.java
+++ b/src/gui/core/plugin/userui/src/main/java/it/geosolutions/geofence/gui/client/widget/tab/ProfilesTabItem.java
@@ -32,13 +32,14 @@
  */
 package it.geosolutions.geofence.gui.client.widget.tab;
 
-import com.extjs.gxt.ui.client.Style.Scroll;
-import com.extjs.gxt.ui.client.widget.TabItem;
-
 import it.geosolutions.geofence.gui.client.Constants;
 import it.geosolutions.geofence.gui.client.Resources;
+import it.geosolutions.geofence.gui.client.service.GsUsersManagerRemoteServiceAsync;
 import it.geosolutions.geofence.gui.client.service.ProfilesManagerRemoteServiceAsync;
 import it.geosolutions.geofence.gui.client.widget.ProfileManagementWidget;
+
+import com.extjs.gxt.ui.client.Style.Scroll;
+import com.extjs.gxt.ui.client.widget.TabItem;
 
 
 // TODO: Auto-generated Javadoc
@@ -72,7 +73,7 @@ public class ProfilesTabItem extends TabItem
      *            the profiles manager service remote
      */
     public ProfilesTabItem(String tabItemId,
-        ProfilesManagerRemoteServiceAsync profilesManagerServiceRemote)
+        ProfilesManagerRemoteServiceAsync profilesManagerServiceRemote, GsUsersManagerRemoteServiceAsync gsManagerServiceRemote)
     {
         this(tabItemId);
         setScrollMode(Scroll.NONE);
@@ -84,7 +85,9 @@ public class ProfilesTabItem extends TabItem
 
         getProfileManagementWidget().getProfilesInfo().getLoader().load(0,
             it.geosolutions.geofence.gui.client.Constants.DEFAULT_PAGESIZE);
-
+        
+        //Deactivate the "Groups" tab as configured in the activateTabs.property (Use Case geostoreIntegration)  
+        TabUtils.deactivateTabIfNeeded(gsManagerServiceRemote, this);
     }
 
     /**

--- a/src/gui/core/plugin/userui/src/main/java/it/geosolutions/geofence/gui/client/widget/tab/TabUtils.java
+++ b/src/gui/core/plugin/userui/src/main/java/it/geosolutions/geofence/gui/client/widget/tab/TabUtils.java
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (C) 2007-2012 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ *  GPLv3 + Classpath exception
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package it.geosolutions.geofence.gui.client.widget.tab;
+
+import it.geosolutions.geofence.gui.client.service.GsUsersManagerRemoteServiceAsync;
+
+import com.extjs.gxt.ui.client.widget.TabItem;
+import com.google.gwt.user.client.rpc.AsyncCallback;
+
+/**
+ * @author DamianoG
+ *
+ */
+public class TabUtils {
+
+    /**
+     * This method performs a server-side async call to retrieve the value in the configuration 
+     * deactivate the tab provided as parameter
+     * 
+     * @param gsManagerServiceRemote
+     * @param tabToDeactivate
+     */
+    public static void deactivateTabIfNeeded(GsUsersManagerRemoteServiceAsync gsManagerServiceRemote, final TabItem tabToDeactivate){
+        
+        AsyncCallback callback = new AsyncCallback() {
+            public void onSuccess(Object result) {
+                if(!(Boolean)result){
+                    tabToDeactivate.setEnabled(false);
+                    tabToDeactivate.setVisible(false);
+                }
+            }
+
+            public void onFailure(Throwable caught) {
+                
+            }
+          };
+        gsManagerServiceRemote.activateUserGroupTabs(callback);
+    }
+}

--- a/src/gui/core/plugin/userui/src/main/java/it/geosolutions/geofence/gui/server/gwt/GsUsersManagerServiceImpl.java
+++ b/src/gui/core/plugin/userui/src/main/java/it/geosolutions/geofence/gui/server/gwt/GsUsersManagerServiceImpl.java
@@ -32,9 +32,6 @@
  */
 package it.geosolutions.geofence.gui.server.gwt;
 
-import com.extjs.gxt.ui.client.data.PagingLoadResult;
-import com.google.gwt.user.server.rpc.RemoteServiceServlet;
-
 import it.geosolutions.geofence.gui.client.ApplicationException;
 import it.geosolutions.geofence.gui.client.model.GSUser;
 import it.geosolutions.geofence.gui.client.model.data.UserLimitsInfo;
@@ -44,6 +41,9 @@ import it.geosolutions.geofence.gui.spring.ApplicationContextUtil;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.extjs.gxt.ui.client.data.PagingLoadResult;
+import com.google.gwt.user.server.rpc.RemoteServiceServlet;
 
 
 /**
@@ -108,5 +108,13 @@ public class GsUsersManagerServiceImpl extends RemoteServiceServlet implements G
     public UserLimitsInfo saveUserLimitsInfo(UserLimitsInfo userLimitInfo) throws ApplicationException
     {
         return gsUserManagerService.saveUserLimitsInfo(userLimitInfo);
+    }
+
+    /* (non-Javadoc)
+     * @see it.geosolutions.geofence.gui.client.service.GsUsersManagerRemoteService#activateUserGroupTabs()
+     */
+    public boolean activateUserGroupTabs() throws ApplicationException 
+    {
+        return gsUserManagerService.activateUserGroupTabs();
     }
 }

--- a/src/gui/core/plugin/userui/src/main/java/it/geosolutions/geofence/gui/server/service/IGsUsersManagerService.java
+++ b/src/gui/core/plugin/userui/src/main/java/it/geosolutions/geofence/gui/server/service/IGsUsersManagerService.java
@@ -88,4 +88,10 @@ public interface IGsUsersManagerService
      * @return UserLimitInfo
      */
     public UserLimitsInfo saveUserLimitsInfo(UserLimitsInfo userLimitInfo);
+    
+    /**
+     * @return
+     * @throws ApplicationException
+     */
+    public boolean activateUserGroupTabs() throws ApplicationException;
 }

--- a/src/gui/core/plugin/userui/src/main/java/it/geosolutions/geofence/gui/server/service/impl/GsUsersManagerServiceImpl.java
+++ b/src/gui/core/plugin/userui/src/main/java/it/geosolutions/geofence/gui/server/service/impl/GsUsersManagerServiceImpl.java
@@ -42,9 +42,12 @@ import it.geosolutions.geofence.gui.service.GeofenceRemoteService;
 import it.geosolutions.geofence.services.dto.ShortUser;
 import it.geosolutions.geofence.services.exception.NotFoundServiceEx;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Properties;
 import java.util.Set;
 
 import org.slf4j.Logger;
@@ -322,5 +325,33 @@ public class GsUsersManagerServiceImpl implements IGsUsersManagerService
 //        }
 
         return userLimitInfo;
+    }
+
+    /* (non-Javadoc)
+     * @see it.geosolutions.geofence.gui.server.service.IGsUsersManagerService#activateUserGroupTabs()
+     */
+    public boolean activateUserGroupTabs() throws ApplicationException {
+        Properties property = new Properties();
+        InputStream in = getClass().getResourceAsStream("activateTabs.properties");
+        try {
+            property.load(in);
+            String outcome = property.getProperty("activateUserGroupTab");
+            if(outcome.equalsIgnoreCase("true")){
+                return true;
+            }
+        } catch (IOException e) {
+            // TODO Auto-generated catch block
+            logger.error(e.getMessage(), e);
+            throw new ApplicationException(e.getMessage(), e);
+        }
+        finally{
+            try {
+                in.close();
+            } catch (IOException e) {
+                logger.error(e.getMessage(), e);
+                throw new ApplicationException(e.getMessage(), e);
+            }
+        }
+        return false;
     }
 }

--- a/src/gui/core/plugin/userui/src/main/resources/it/geosolutions/geofence/gui/server/service/impl/activateTabs.properties
+++ b/src/gui/core/plugin/userui/src/main/resources/it/geosolutions/geofence/gui/server/service/impl/activateTabs.properties
@@ -1,0 +1,2 @@
+#This property is changed by the maven ant replace task, don't change it manually
+activateUserGroupTab=true

--- a/src/gui/core/plugin/userui/src/test/java/it/geosolutions/geofence/gui/PropertiesLoading.java
+++ b/src/gui/core/plugin/userui/src/test/java/it/geosolutions/geofence/gui/PropertiesLoading.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (C) 2007-2012 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ *  GPLv3 + Classpath exception
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package it.geosolutions.geofence.gui;
+
+import it.geosolutions.geofence.gui.server.service.IGsUsersManagerService;
+import it.geosolutions.geofence.gui.server.service.impl.GsUsersManagerServiceImpl;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author DamianoG
+ *
+ */
+public class PropertiesLoading extends Assert{
+
+    @Test
+    public void testActivateUserGroup(){
+        IGsUsersManagerService service = new GsUsersManagerServiceImpl();
+        boolean outcome = service.activateUserGroupTabs();
+        assertEquals(true, outcome);
+    }
+}

--- a/src/gui/core/plugin/userui/src/test/resources/applicationContext-test.xml
+++ b/src/gui/core/plugin/userui/src/test/resources/applicationContext-test.xml
@@ -1,0 +1,18 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:jaxws="http://cxf.apache.org/jaxws"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xsi:schemaLocation="
+http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+http://cxf.apache.org/jaxws http://cxf.apache.org/schema/jaxws.xsd
+http://www.springframework.org/schema/context
+          http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+	default-autowire="byName">
+
+
+       <bean id="workspaceConfigOpts" class="it.geosolutions.geofence.gui.client.configuration.WorkspaceConfigOpts">
+         <property name="showDefaultGroups" value="false"/>
+       </bean>
+       
+       <context:annotation-config />
+
+</beans>

--- a/src/gui/core/plugin/userui/src/test/resources/it/geosolutions/geofence/gui/server/service/impl/activateTabs.properties
+++ b/src/gui/core/plugin/userui/src/test/resources/it/geosolutions/geofence/gui/server/service/impl/activateTabs.properties
@@ -1,0 +1,1 @@
+activateUserGroupTab=true


### PR DESCRIPTION
in order to test this pull request:

* Craete the geofence database, the version with geostore integration, see how [here](https://github.com/Damianofds/geofence/tree/master/doc/setup/sql/geofence-geostoreUsersIntegration_scripts)
* Build geofence with the profile **-PgeostopreIntegration**
* Deploy it and configure the database previously created as described [here](https://github.com/geosolutions-it/geofence/wiki/GeoFence-configuration#database-configuration)
* Run again the application and check if **Users Management** and **Groups** tabs are deactivated and if, creating a new rule, the groups and roles that appear in the dropdown list are exactly the one stored in geostore
* Build geofence **without** the profile -PgeostopreIntegration, you must see the two tab now, but if the database is still the same configured before trying to insert/update a group or a user will return an error. 